### PR TITLE
Fix: Remove server submodule to resolve Netlify deployment issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,5 +61,8 @@ debug-*.html
 *test.html
 *debug.html
 
+# Server folder (deployed separately)
+server/
+
 # If you intentionally want to ignore large images, add patterns here
 # e.g. to ignore all PNGs: # *.png


### PR DESCRIPTION
- Moved server folder out of pages directory
- Removed git submodule reference for pages/server
- Added server/ to .gitignore (deployed separately on Render)
- This fixes the 'No url found for submodule path' error in Netlify